### PR TITLE
Remove radialpoint

### DIFF
--- a/enterprise-and-python.md
+++ b/enterprise-and-python.md
@@ -96,7 +96,6 @@ Fork and open a pull request to update this list.
 * [PasswordBox](https://www.passwordbox.com) // Intel Corporation
 * [Pivotal Payments](http://www.pivotalpayments.com/)
 * [Plotly](https://plot.ly/)
-* [Radialpoint](https://www.radialpoint.com/)
 * [Rodeo FX](http://www.rodeofx.com/)
 * [SecureOps](https://www.secureops.com/)
 * [Shopify](http://www.shopify.ca/)


### PR DESCRIPTION
The link was broken (starting with `www`), I added `https://` and then noticed that it doesn’t work.  Trying with `http://` we can see that the page is redirected to another company.

Should check the status of radialpoint and remove or update their line.